### PR TITLE
Formating flask URLs into Swagger URLs for proper path params handling.

### DIFF
--- a/flask_restful_swagger_2/__init__.py
+++ b/flask_restful_swagger_2/__init__.py
@@ -3,8 +3,9 @@ import inspect
 from flask.ext.restful import Api as restful_Api, abort as flask_abort, Resource as flask_Resource
 from flask import request
 
-from flask.ext.restful_swagger_2.swagger import create_swagger_endpoint, validate_path_item_object, ValidationError, \
-    validate_operation_object, validate_definitions_object, _auth as auth
+from flask.ext.restful_swagger_2.swagger import create_swagger_endpoint, validate_path_item_object, \
+    ValidationError, validate_operation_object, validate_definitions_object, extract_swagger_path, \
+    _auth as auth
 
 
 def abort(http_status_code, schema=None, **kwargs):
@@ -81,7 +82,7 @@ class Api(restful_Api):
             for url in urls:
                 if not url.startswith('/'):
                     raise ValidationError('paths must start with a /')
-                self._swagger_object['paths'][url] = path_item
+                self._swagger_object['paths'][extract_swagger_path(url)] = path_item
         super(Api, self).add_resource(resource, *urls, **kwargs)
 
     def _extract_schemas(self, obj):

--- a/flask_restful_swagger_2/swagger.py
+++ b/flask_restful_swagger_2/swagger.py
@@ -1,3 +1,5 @@
+import re
+
 from flask import request
 from flask.ext.restful import Resource
 
@@ -206,3 +208,13 @@ def validate_headers_object(headers_object):
 
 def validate_example_object(example_object):
     pass
+
+
+def extract_swagger_path(path):
+    """
+    Extracts a swagger type path from the given flask style path.
+    This /path/<parameter> turns into this /path/{parameter}
+    And this /<string(length=2):lang_code>/<string:id>/<float:probability>
+    to this: /{lang_code}/{id}/{probability}
+    """
+    return re.sub('<(?:[^:]+:)?([^>]+)>', '{\\1}', path)


### PR DESCRIPTION
Hi!

I propose this change so that we can handle properly `path` parameters. I use it this way:

    @swagger.doc({
        'tags': ['Product'],
        'summary': 'Get one product by id',
        'parameters': [
            {
                'name': 'product_id',
                'description': 'this is the product id',
                'in': 'path',
                'type': 'string',
                'required': True,
            }
        ],
        'responses': {
            '200': { 'description': 'return the product' }
        }
    })
    def get(self, product_id):
       pass


    api.add_resource(ProductResource, '/products/<string:product_id>')
