### PR TITLE
Ability to pass your own Swagger template

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Api class supports the following parameters:
 | --------- | ----------- |
 | `api_version` | The API version string (defaults to '0.0'). Maps to the `version` field of the [info object](http://swagger.io/specification/#infoObject). |
 | `api_spec_url` | The URL path that serves the swagger specification document (defaults to `/api/swagger`). |
+| `api_spec_base` | Instead of specifying individual Swagger fields, you can pass in a minimal [schema object](http://swagger.io/specification/#schemaObject) to use as a template. |
 | `base_path` | The base path on which the API is served. Maps to the `basePath` field of the [schema object](http://swagger.io/specification/#schemaObject). |
 | `consumes` | A list of MIME types the API can consume. Maps to the `consumes` field of the [schema object](http://swagger.io/specification/#schemaObject). |
 | `contact` | The contact information for the API. Maps to the `contact` field of the [info object](http://swagger.io/specification/#infoObject). |

--- a/flask_restful_swagger_2/__init__.py
+++ b/flask_restful_swagger_2/__init__.py
@@ -1,4 +1,5 @@
 import inspect
+import copy
 
 from flask_restful import Api as restful_Api, abort as flask_abort, Resource as flask_Resource
 from flask import request
@@ -39,31 +40,36 @@ def auth_required(f):
 class Resource(flask_Resource):
     decorators = [auth_required]
 
-
 class Api(restful_Api):
     def __init__(self, *args, **kwargs):
-        self._swagger_object = {
-            'swagger': '2.0',
-            'info': {
-                'title': kwargs.pop('title', ''),
-                'description': kwargs.pop('description', ''),
-                'termsOfService': kwargs.pop('terms', ''),
-                'version': kwargs.pop('api_version', '0.0')
-            },
-            'host': kwargs.pop('host', ''),
-            'basePath': kwargs.pop('base_path', ''),
-            'schemes': kwargs.pop('schemes', []),
-            'consumes': kwargs.pop('consumes', []),
-            'produces': kwargs.pop('produces', []),
-            'paths': {},
-            'definitions': {},
-            'parameters': {},
-            'responses': {},
-            'securityDefinitions': {},
-            'security': [],
-            'tags': kwargs.pop('tags', []),
-            'externalDocs': {}
-        }
+        api_spec_base = kwargs.pop('api_spec_base', None)
+
+        if api_spec_base is not None:
+            self._swagger_object = copy.deepcopy(api_spec_base)
+        else:
+            self._swagger_object = {
+                'swagger': '2.0',
+                'info': {
+                    'title': kwargs.pop('title', ''),
+                    'description': kwargs.pop('description', ''),
+                    'termsOfService': kwargs.pop('terms', ''),
+                    'version': kwargs.pop('api_version', '0.0')
+                },
+                'host': kwargs.pop('host', ''),
+                'basePath': kwargs.pop('base_path', ''),
+                'schemes': kwargs.pop('schemes', []),
+                'consumes': kwargs.pop('consumes', []),
+                'produces': kwargs.pop('produces', []),
+                'paths': {},
+                'definitions': {},
+                'parameters': {},
+                'responses': {},
+                'securityDefinitions': {},
+                'security': [],
+                'tags': kwargs.pop('tags', []),
+                'externalDocs': {}
+            }
+
         contact = kwargs.pop('contact', {})
         if contact:
             self._swagger_object['info']['contact'] = contact


### PR DESCRIPTION
Instead of adding an option per Swagger field to custom, you can pass in a minimal Swagger object to use as a template.
