### PR TITLE
Ability to skip creation of Swagger resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The Api class supports the following parameters:
 | `schemes` | The transfer protocol of the API. Maps the the `schemes` field of the [schema object](http://swagger.io/specification/#schemaObject). |
 | `terms` | The terms of service for the API. Maps to the `termsOfService` field of the [info object](http://swagger.io/specification/#infoObject). |
 | `title` | The title of the application (defaults to the flask app module name). Maps to the `title` field of the [info object](http://swagger.io/specification/#infoObject). |
+| `add_api_spec_resource` | Set to `False` if you want to apply custom decorators to the Swagger resource and manually register it (defaults to `True`) |
 
 ## Documenting API endpoints
 

--- a/flask_restful_swagger_2/__init__.py
+++ b/flask_restful_swagger_2/__init__.py
@@ -71,14 +71,18 @@ class Api(restful_Api):
         if license:
             self._swagger_object['info']['license'] = license
         api_spec_url = kwargs.pop('api_spec_url', '/api/swagger')
+        add_api_spec_resource = kwargs.pop('add_api_spec_resource', True)
         super(Api, self).__init__(*args, **kwargs)
         if self.app and not self._swagger_object['info']['title']:
             self._swagger_object['info']['title'] = self.app.name
-        api_spec_urls = [
-            '{0}.json'.format(api_spec_url),
-            '{0}.html'.format(api_spec_url),
-        ]
-        self.add_resource(create_swagger_endpoint(self), *api_spec_urls, endpoint='swagger')
+
+        # Unless told otherwise, create and register the swagger endpoint
+        if add_api_spec_resource:
+            api_spec_urls = [
+                '{0}.json'.format(api_spec_url),
+                '{0}.html'.format(api_spec_url),
+            ]
+            self.add_resource(create_swagger_endpoint(self), *api_spec_urls, endpoint='swagger')
 
     def add_resource(self, resource, *urls, **kwargs):
         path_item = {}


### PR DESCRIPTION
This is useful if you need to apply custom decorators to the Swagger resource before it's registered.