### PR TITLE
allow inherited resource class to be added

### DIFF
--- a/flask_restful_swagger_2/__init__.py
+++ b/flask_restful_swagger_2/__init__.py
@@ -100,7 +100,7 @@ class Api(restful_Api):
         definitions = {}
 
         for method in [m.lower() for m in resource.methods]:
-            f = resource.__dict__.get(method, None)
+            f = getattr(resource, method)
             if f:
                 operation = f.__dict__.get('__swagger_operation_object', None)
                 if operation:


### PR DESCRIPTION
add_resource method of Api class searches for declared methods ['GET','POST'...] inside:
f = resource.dict.get(method, None)
dict only reflect the local class methods to be able to reflect base class method we can use
f = getattr(resource,method)
this will allow for instance to inherit a base class CustomerResource(Resource) which has property many=False into another class CustomersResource(CustomerResource) with many=True overloaded
then we could declare:
api.add_resource(CustomerResource, '/api/customer')
api.add_resource(CustomersResource, '/api/customers')